### PR TITLE
Allow configuration of Ollama base URL

### DIFF
--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -82,7 +82,7 @@ function baseURLForProvider(provider: string): string {
     case "openai":
       return "https://api.openai.com/v1";
     case "ollama":
-      return "http://localhost:11434/v1";
+      return process.env["OLLAMA_BASE_URL"] ?? "http://localhost:11434/v1";
     case "gemini":
       return "https://generativelanguage.googleapis.com/v1beta/openai/";
     case "openrouter":


### PR DESCRIPTION
Enable the configuration of the Ollama base URL through an environment variable, providing flexibility for different deployment scenarios, such as a remote-hosted Ollama server.