### PR TITLE
Fixes Conflicts with codex and open-codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,7 @@ The hardening mechanism Codex uses depends on your OS:
 
 - **macOS 12+** – commands are wrapped with **Apple Seatbelt** (`sandbox-exec`).
 
-  - Everything is placed in a read‑only jail except for a small set of
-    writable roots (`$PWD`, `$TMPDIR`, `~/.codex`, etc.).
+  writable roots (`$PWD`, `$TMPDIR`, `~/.open-codex`, etc.).
   - Outbound network is _fully blocked_ by default – even if a child process
     tries to `curl` somewhere it will fail.
 
@@ -180,7 +179,7 @@ Key flags: `--model/-m`, `--approval-mode/-a`, and `--quiet/-q`.
 
 Codex merges Markdown instructions in this order:
 
-1. `~/.codex/instructions.md` – personal global guidance
+1. `~/.open-codex/instructions.md` – personal global guidance
 2. `codex.md` at repo root – shared project notes
 3. `codex.md` in cwd – sub‑package specifics
 
@@ -269,10 +268,10 @@ npm link
 
 ## Configuration
 
-Codex looks for config files in **`~/.codex/`**.
+Codex looks for config files in **`~/.open-codex/`**.
 
 ```json
-// ~/.codex/config.json
+// ~/.open-codex/config.json
 {
   "model": "o4-mini", // Default model
   "provider": "openai", // Default provider
@@ -283,7 +282,7 @@ Codex looks for config files in **`~/.codex/`**.
 You can also define custom instructions:
 
 ```md
-# ~/.codex/instructions.md
+# ~/.open-codex/instructions.md
 
 - Always respond with emojis
 - Only use git commands if I explicitly mention you should

--- a/codex-cli/examples/prompting_guide.md
+++ b/codex-cli/examples/prompting_guide.md
@@ -47,7 +47,7 @@ Enter "q" to exit out of the current session and `open poem.html`. You should se
 
 Codex supports two types of Markdown-based instruction files that influence model behavior and prompting:
 
-### `~/.codex/instructions.md`
+### `~/.open-codex/instructions.md`
 Global, user-level custom guidance injected into every session. You should keep this relatively short and concise. These instructions are applied to all Codex runs across all projects and are great for personal defaults, shell setup tips, safety constraints, or preferred tools.
 
 **Example:** "Before executing shell commands, create and activate a `.codex-venv` Python environment." or "Avoid running pytest until you've completed all your changes."

--- a/codex-cli/src/utils/agent/sandbox/macos-seatbelt.ts
+++ b/codex-cli/src/utils/agent/sandbox/macos-seatbelt.ts
@@ -23,7 +23,7 @@ export function execWithSeatbelt(
   let scopedWritePolicy: string;
   let policyTemplateParams: Array<string>;
   if (writableRoots.length > 0) {
-    // Add `~/.codex` to the list of writable roots
+    // Add `~/.open-codex` to the list of writable roots
     // (if there's any already, not in read-only mode)
     getCommonRoots().map((root) => writableRoots.push(root));
     const { policies, params } = writableRoots

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -19,7 +19,7 @@ import { dirname, join, extname, resolve as resolvePath } from "path";
 export const DEFAULT_APPROVAL_MODE = AutoApprovalMode.SUGGEST;
 export const DEFAULT_INSTRUCTIONS = "";
 
-export const CONFIG_DIR = join(homedir(), ".codex");
+export const CONFIG_DIR = join(homedir(), ".open-codex");
 export const CONFIG_JSON_FILEPATH = join(CONFIG_DIR, "config.json");
 export const CONFIG_YAML_FILEPATH = join(CONFIG_DIR, "config.yaml");
 export const CONFIG_YML_FILEPATH = join(CONFIG_DIR, "config.yml");
@@ -402,7 +402,7 @@ export const loadConfig = (
   // -----------------------------------------------------------------------
   // First‑run bootstrap: if the configuration file (and/or its containing
   // directory) didn't exist we create them now so that users end up with a
-  // materialised ~/.codex/config.json file on first execution.  This mirrors
+  // materialised ~/.open-codex/config.json file on first execution.  This mirrors
   // what `saveConfig()` would do but without requiring callers to remember to
   // invoke it separately.
   //


### PR DESCRIPTION
This is totally an optional PR but I noticed while running both codex and open-codex box projects looks for the same config file.

To Fix this:
I’ve updated the default config directory from `~/.codex ` to `~/.open-codex,` adjusted all related constants .

with these changes the CLI will now look only in `~/.open-codex/` for its config and instructions, so it won’t collide with anything in `~/.codex/`

