### PR TITLE
fix: help text for provider short option

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -54,7 +54,7 @@ const cli = meow(
 
   Options
     -h, --help                 Show usage and exit
-    -m  --provider <provider>  Provider to use for completions (default: openai, options: openai, gemini, openrouter, ollama, xai)
+    -p, --provider <provider>  Provider to use for completions (default: openai, options: openai, gemini, openrouter, ollama, xai)
     -m, --model <model>        Model to use for completions (default: o4-mini)
     -i, --image <path>         Path(s) to image files to include as input
     -v, --view <rollout>       Inspect a previously saved rollout instead of starting a session


### PR DESCRIPTION
This pull request addresses the issue where the help text displays the incorrect short option for `--provider`. 

Fixes issue #21