### PR TITLE
Fix: Run firewall initialization as root and update open-codex command

### DIFF
--- a/codex-cli/Dockerfile
+++ b/codex-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22-slim
 
 ARG TZ
 ENV TZ="$TZ"

--- a/codex-cli/package-lock.json
+++ b/codex-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-codex",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-codex",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "license": "Apache-2.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",

--- a/codex-cli/scripts/run_in_container.sh
+++ b/codex-cli/scripts/run_in_container.sh
@@ -57,8 +57,8 @@ docker run --name "$CONTAINER_NAME" -d \
   codex \
   sleep infinity
 
-# Initialize the firewall inside the container.
-docker exec "$CONTAINER_NAME" bash -c "sudo /usr/local/bin/init_firewall.sh"
+# Initialize the firewall inside the container as root.
+docker exec --user root "$CONTAINER_NAME" bash -c "/usr/local/bin/init_firewall.sh"
 
 # Execute the provided command in the container, ensuring it runs in the work directory.
 # We use a parameterized bash command to safely handle the command and directory.
@@ -67,4 +67,4 @@ quoted_args=""
 for arg in "$@"; do
   quoted_args+=" $(printf '%q' "$arg")"
 done
-docker exec -it "$CONTAINER_NAME" bash -c "cd \"/app$WORK_DIR\" && codex --full-auto ${quoted_args}"
+docker exec -it "$CONTAINER_NAME" bash -c "cd \"/app$WORK_DIR\" && open-codex --full-auto ${quoted_args}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "codex",
+  "name": "open-codex",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
**This has these updates:**

- run firewall initialization as root and update command to open-codex
- update base image to node:22-slim
- bump version to 0.1.31 and update package name to open-codex

