### PR TITLE
Add read-only HTTP server functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ yarn-error.log*
 # env
 .env*
 !.env.example
+env/
 
 # package
 *.tgz

--- a/codex-cli/examples/http-server/README.md
+++ b/codex-cli/examples/http-server/README.md
@@ -1,0 +1,107 @@
+# HTTP Server Mode (Read-Only)
+
+The Codex CLI can now run as an HTTP server, providing a REST API interface for code analysis and exploration. **HTTP mode is read-only** - it can analyze your codebase, search files, and answer questions, but cannot modify files or execute commands.
+
+## Quick Start
+
+Start the HTTP server:
+
+```bash
+open-codex server --port 8080 --host 0.0.0.0
+```
+
+## API Endpoints
+
+### POST /chat
+
+Send a chat message to the AI agent.
+
+**Request Body:**
+```json
+{
+  "prompt": "Explain what this Python file does",
+  "sessionId": "optional-session-id",
+  "imagePaths": ["path/to/image.png"]
+}
+```
+
+Note: `approvalMode` is ignored - HTTP mode is always read-only.
+
+**Response:**
+```json
+{
+  "sessionId": "uuid-string",
+  "messages": [
+    {
+      "role": "user", 
+      "content": "Write a simple Python hello world script"
+    },
+    {
+      "role": "assistant",
+      "content": "I'll create a simple Python hello world script for you.",
+      "tool_calls": [...]
+    }
+  ],
+  "status": "completed"
+}
+```
+
+### GET /health
+
+Health check endpoint.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "version": "0.1.31"
+}
+```
+
+### DELETE /sessions/{sessionId}
+
+Terminate a specific session.
+
+**Response:**
+```json
+{
+  "message": "Session terminated"
+}
+```
+
+## Read-Only Capabilities
+
+HTTP mode supports these operations:
+- **File Reading**: Read any file in the codebase
+- **Code Search**: Search for patterns, functions, or text
+- **Code Analysis**: Explain code functionality, identify patterns
+- **Documentation**: Generate explanations and documentation
+- **Code Exploration**: Navigate and understand project structure
+
+HTTP mode **blocks** these operations:
+- File editing or creation
+- Command execution
+- Any modification operations
+
+## Example Usage
+
+```bash
+# Start server
+open-codex server --port 3000
+
+# Send a chat request
+curl -X POST http://localhost:3000/chat \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Analyze the main server file and explain how it works"
+  }'
+
+# Check health
+curl http://localhost:3000/health
+```
+
+## Session Management
+
+The HTTP server maintains sessions to preserve conversation context. If you don't provide a `sessionId`, a new session will be created. Reuse the same `sessionId` to continue a conversation.
+
+Sessions can be terminated using the DELETE endpoint to free up resources.

--- a/codex-cli/examples/http-server/demo.sh
+++ b/codex-cli/examples/http-server/demo.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Demo script for Codex HTTP server
+# This script demonstrates how to use the HTTP API
+
+echo "🚀 Starting Codex HTTP Server Demo"
+echo ""
+
+# Check if server is running
+echo "📋 Checking server health..."
+if curl -s http://localhost:3000/health > /dev/null; then
+    echo "✅ Server is running!"
+else
+    echo "❌ Server is not running. Please start it with:"
+    echo "   open-codex server --port 3000"
+    echo ""
+    echo "Or build and run from source:"
+    echo "   npm run build && node dist/cli.js server --port 3000"
+    exit 1
+fi
+
+echo ""
+
+# Test health endpoint
+echo "🔍 Health check response:"
+curl -s http://localhost:3000/health | jq .
+echo ""
+
+# Test simple chat
+echo "💬 Testing simple chat (suggest mode):"
+curl -s -X POST http://localhost:3000/chat \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Explain what is HTTP in simple terms",
+    "approvalMode": "suggest"
+  }' | jq '.sessionId, .status, .messages | length'
+
+echo ""
+
+# Test auto-edit mode
+echo "🛠️  Testing auto-edit mode:"
+curl -s -X POST http://localhost:3000/chat \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Create a simple package.json file for a Node.js project",
+    "approvalMode": "auto-edit"
+  }' | jq '.sessionId, .status, .messages | length'
+
+echo ""
+echo "✅ Demo completed! Check the server logs for detailed output."
+echo ""
+echo "💡 Try the interactive test client:"
+echo "   node examples/http-server/test-client.js \"Write a hello world script\""

--- a/codex-cli/examples/http-server/test-client.js
+++ b/codex-cli/examples/http-server/test-client.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+/**
+ * Simple test client for Codex HTTP server (Read-Only Mode)
+ * 
+ * Usage:
+ *   node test-client.js "Explain what this codebase does"
+ *   node test-client.js "Find all the React components in this project"
+ *   node test-client.js "What's the main entry point of this application?"
+ * 
+ * Note: HTTP mode is read-only - it can analyze code but not modify it.
+ */
+
+import http from 'node:http';
+
+const BASE_URL = 'http://localhost:3000';
+
+async function makeRequest(method, path, data = null) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(path, BASE_URL);
+    const options = {
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname,
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const req = http.request(options, (res) => {
+      let body = '';
+      res.on('data', (chunk) => body += chunk);
+      res.on('end', () => {
+        try {
+          const result = JSON.parse(body);
+          resolve({ status: res.statusCode, data: result });
+        } catch (e) {
+          resolve({ status: res.statusCode, data: body });
+        }
+      });
+    });
+
+    req.on('error', reject);
+
+    if (data) {
+      req.write(JSON.stringify(data));
+    }
+    req.end();
+  });
+}
+
+async function testChat(prompt, approvalMode = 'suggest') {
+  console.log(`🤖 Sending: "${prompt}"`);
+  console.log(`📋 Mode: Read-Only (HTTP mode ignores approval mode)`);
+  console.log('⏳ Waiting for response...\n');
+  
+  try {
+    const result = await makeRequest('POST', '/chat', {
+      prompt,
+    });
+
+    if (result.status === 200) {
+      console.log(`✅ Session ID: ${result.data.sessionId}`);
+      console.log(`📊 Status: ${result.data.status}`);
+      console.log(`💬 Messages received: ${result.data.messages.length}\n`);
+      
+      // Display conversation
+      for (const message of result.data.messages) {
+        if (message.role === 'assistant' && typeof message.content === 'string') {
+          console.log(`🤖 Assistant: ${message.content.substring(0, 200)}${message.content.length > 200 ? '...' : ''}`);
+        } else if (message.role === 'tool') {
+          console.log(`🔧 Tool output received`);
+        }
+      }
+      
+      if (result.data.error) {
+        console.log(`❌ Error: ${result.data.error}`);
+      }
+    } else {
+      console.log(`❌ Error ${result.status}:`, result.data);
+    }
+  } catch (error) {
+    console.log(`❌ Request failed:`, error.message);
+  }
+}
+
+async function testHealth() {
+  console.log('🔍 Checking server health...');
+  try {
+    const result = await makeRequest('GET', '/health');
+    console.log('✅ Health check:', result.data);
+  } catch (error) {
+    console.log('❌ Health check failed:', error.message);
+  }
+  console.log('');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const prompt = args.find(arg => !arg.startsWith('--'));
+  const approvalModeIndex = args.indexOf('--approval-mode');
+  const approvalMode = approvalModeIndex >= 0 ? args[approvalModeIndex + 1] : 'suggest';
+
+  if (!prompt) {
+    console.log('Usage: node test-client.js "your prompt here"');
+    console.log('Examples:');
+    console.log('  node test-client.js "Explain what this codebase does"');
+    console.log('  node test-client.js "Find all TypeScript files in src/"');
+    console.log('  node test-client.js "What are the main components in this React app?"');
+    process.exit(1);
+  }
+
+  await testHealth();
+  await testChat(prompt, approvalMode);
+}
+
+main().catch(console.error);

--- a/codex-cli/package-lock.json
+++ b/codex-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-codex",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-codex",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "license": "Apache-2.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",

--- a/codex-cli/src/server.ts
+++ b/codex-cli/src/server.ts
@@ -1,0 +1,286 @@
+import type { ApprovalPolicy } from "./approvals.js";
+import type { CommandConfirmation } from "./utils/agent/agent-loop.js";
+import type { AppConfig } from "./utils/config.js";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions/completions.mjs";
+
+import { AgentLoop } from "./utils/agent/agent-loop.js";
+import { ReviewDecision } from "./utils/agent/review.js";
+import { AutoApprovalMode } from "./utils/auto-approval-mode.js";
+import { createInputItem } from "./utils/input-utils.js";
+import { randomUUID } from "node:crypto";
+
+type ServerConfig = {
+  port: number;
+  host: string;
+  config: AppConfig;
+};
+
+type ChatRequest = {
+  prompt: string;
+  imagePaths?: Array<string>;
+  approvalMode?: "suggest" | "auto-edit" | "full-auto"; // Note: HTTP mode forces read-only
+  sessionId?: string;
+};
+
+type ChatResponse = {
+  sessionId: string;
+  messages: Array<ChatCompletionMessageParam>;
+  status: "completed" | "error";
+  error?: string;
+};
+
+// Store active sessions
+const activeSessions = new Map<string, AgentLoop>();
+
+// Define read-only tool functions (tools that only read, don't modify)
+const READ_ONLY_TOOLS = new Set([
+  "Read",
+  "Glob", 
+  "Grep",
+  "LS",
+  "NotebookRead",
+  "WebFetch",
+  "WebSearch",
+  "TodoRead"
+]);
+
+// Tools that modify files or execute commands (blocked in HTTP mode)
+const WRITE_TOOLS = new Set([
+  "Edit",
+  "MultiEdit", 
+  "Write",
+  "NotebookEdit",
+  "Bash",
+  "TodoWrite",
+  "Task"
+]);
+
+function isReadOnlyToolCall(toolCall: any): boolean {
+  const functionName = toolCall?.function?.name;
+  return READ_ONLY_TOOLS.has(functionName);
+}
+
+function isWriteToolCall(toolCall: any): boolean {
+  const functionName = toolCall?.function?.name;
+  return WRITE_TOOLS.has(functionName);
+}
+
+function filterMessageForReadOnly(item: ChatCompletionMessageParam): ChatCompletionMessageParam | null {
+  // If it's an assistant message with tool calls, filter out write operations
+  if (item.role === "assistant" && "tool_calls" in item && item.tool_calls) {
+    const writeToolCalls = item.tool_calls.filter(isWriteToolCall);
+    const readToolCalls = item.tool_calls.filter(isReadOnlyToolCall);
+    
+    // If there are write tool calls, replace with a friendly message
+    if (writeToolCalls.length > 0) {
+      const writeOperations = writeToolCalls.map(tc => tc.function.name).join(", ");
+      const friendlyMessage = `I can see you'd like me to perform write operations (${writeOperations}), but I'm running in read-only mode via HTTP. I can help you understand your codebase, analyze files, search for patterns, and answer questions, but I cannot modify files or execute commands.\n\nWould you like me to help you explore or analyze your code instead?`;
+      
+      // If there are also read operations, keep those and add the message
+      if (readToolCalls.length > 0) {
+        return {
+          ...item,
+          tool_calls: readToolCalls,
+          content: (typeof item.content === "string" ? item.content + "\n\n" : "") + friendlyMessage
+        };
+      } else {
+        // Only write operations - replace with friendly message
+        return {
+          ...item,
+          tool_calls: undefined,
+          content: friendlyMessage
+        };
+      }
+    }
+  }
+  
+  // For tool responses from write operations, don't include them
+  if (item.role === "tool" && "tool_call_id" in item) {
+    // We can't easily determine if this was from a write tool without more context
+    // So we'll let tool responses through, but they shouldn't happen since we filter the calls
+    return item;
+  }
+  
+  // Pass through all other messages unchanged
+  return item;
+}
+
+export async function runServer({ port, host, config }: ServerConfig): Promise<void> {
+  // Use Node.js built-in HTTP server to avoid external dependencies
+  const { createServer } = await import("node:http");
+  const { parse } = await import("node:url");
+  
+  const server = createServer(async (req, res) => {
+    // Enable CORS
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    
+    if (req.method === "OPTIONS") {
+      res.writeHead(200);
+      res.end();
+      return;
+    }
+
+    const url = parse(req.url || "", true);
+    
+    try {
+      if (req.method === "POST" && url.pathname === "/chat") {
+        await handleChatRequest(req, res, config);
+      } else if (req.method === "GET" && url.pathname === "/health") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "ok", version: "0.1.31" }));
+      } else if (req.method === "DELETE" && url.pathname?.startsWith("/sessions/")) {
+        const sessionId = url.pathname.split("/")[2];
+        if (sessionId) {
+          await handleSessionTerminate(res, sessionId);
+        } else {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Session ID required" }));
+        }
+      } else {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Not found" }));
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error("Server error:", error);
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Internal server error" }));
+    }
+  });
+
+  // Return a promise that resolves when server starts
+  return new Promise<void>((resolve, reject) => {
+    server.on('error', (error) => {
+      console.error("❌ Server error:", error);
+      reject(error);
+    });
+    
+    server.listen(port, host, () => {
+      // eslint-disable-next-line no-console
+      console.log(`🚀 Codex HTTP server running at http://${host}:${port} (READ-ONLY MODE)`);
+      // eslint-disable-next-line no-console
+      console.log(`📋 Health check: http://${host}:${port}/health`);
+      // eslint-disable-next-line no-console
+      console.log(`💬 Chat endpoint: POST http://${host}:${port}/chat`);
+      // eslint-disable-next-line no-console
+      console.log(`🔒 Note: HTTP mode only allows read operations (file analysis, code exploration)`);
+      resolve();
+    });
+  });
+}
+
+async function handleChatRequest(
+  req: NodeJS.ReadableStream,
+  res: NodeJS.WritableStream & { writeHead: (code: number, headers?: Record<string, string>) => void; end: (data?: string) => void },
+  config: AppConfig
+): Promise<void> {
+  let body = "";
+  
+  for await (const chunk of req) {
+    body += chunk.toString();
+  }
+
+  const chatRequest: ChatRequest = JSON.parse(body);
+  const sessionId = chatRequest.sessionId || randomUUID();
+  
+  // HTTP mode is always read-only - force SUGGEST mode regardless of request
+  const approvalPolicy: ApprovalPolicy = AutoApprovalMode.SUGGEST;
+
+  const messages: Array<ChatCompletionMessageParam> = [];
+  let hasError = false;
+  let errorMessage = "";
+
+  try {
+    // Create or reuse agent for this session
+    let agent = activeSessions.get(sessionId);
+    
+    if (!agent) {
+      // Add read-only instructions to the existing instructions
+      const readOnlyInstructions = `${config.instructions || ""}
+
+IMPORTANT: You are running in READ-ONLY HTTP mode. You can only:
+- Read files (Read, Glob, Grep, LS, NotebookRead)
+- Search and analyze code
+- Answer questions about the codebase
+- Provide explanations and documentation
+
+You CANNOT:
+- Edit or write files (Edit, MultiEdit, Write, NotebookEdit)
+- Execute commands (Bash)
+- Create todos (TodoWrite)
+- Perform any modification operations
+
+If the user asks you to modify files or run commands, politely explain that you're in read-only mode and offer to help with code analysis instead.`;
+
+      agent = new AgentLoop({
+        model: config.model,
+        config: config,
+        instructions: readOnlyInstructions,
+        approvalPolicy,
+        onItem: (item: ChatCompletionMessageParam) => {
+          // Filter and modify messages for read-only mode
+          const filteredItem = filterMessageForReadOnly(item);
+          if (filteredItem) {
+            messages.push(filteredItem);
+          }
+        },
+        onLoading: () => {
+          // HTTP doesn't need loading indicators
+        },
+        getCommandConfirmation: (
+          _command: Array<string>,
+        ): Promise<CommandConfirmation> => {
+          // In HTTP read-only mode, always deny command execution
+          return Promise.resolve({ review: ReviewDecision.NO_CONTINUE });
+        },
+        onReset: () => {
+          // Reset handled internally
+        },
+      });
+      
+      activeSessions.set(sessionId, agent);
+    }
+
+    const inputItem = await createInputItem(
+      chatRequest.prompt,
+      chatRequest.imagePaths || []
+    );
+    
+    await agent.run([inputItem]);
+
+  } catch (error) {
+    hasError = true;
+    errorMessage = error instanceof Error ? error.message : "Unknown error";
+    // eslint-disable-next-line no-console
+    console.error("Agent error:", error);
+  }
+
+  const response: ChatResponse = {
+    sessionId,
+    messages,
+    status: hasError ? "error" : "completed",
+    ...(hasError && { error: errorMessage }),
+  };
+
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(response, null, 2));
+}
+
+async function handleSessionTerminate(
+  res: NodeJS.WritableStream & { writeHead: (code: number, headers?: Record<string, string>) => void; end: (data?: string) => void }, 
+  sessionId: string
+): Promise<void> {
+  const agent = activeSessions.get(sessionId);
+  
+  if (agent) {
+    agent.terminate();
+    activeSessions.delete(sessionId);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ message: "Session terminated" }));
+  } else {
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Session not found" }));
+  }
+}


### PR DESCRIPTION
- Add HTTP server mode via 'open-codex server' command
- Implement read-only API for code analysis and exploration
- Add session management with conversation context
- Filter out write operations (Edit, Write, Bash, etc.)
- Provide friendly messages when users try to modify files
- Include documentation and test clients
- Remove env/ folder from git tracking